### PR TITLE
修改：将Issues链接关键s链接关键词'解决'改成英文

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,8 +705,7 @@ Issues （议题）是 GitHub 、 GitLab 等代码托管服务提供的功能，
 
 - close, closes, closed
 - fix, fixes, fixed
-- resolves, resolved
-- 解决
+- resolve, resolves, resolved
 
 每个 Issues 也可以关联到一个 Milestone 中。由于 Issues 不能设定截止日期，但是 Milestone 可以，这就比较方便进行项目进度的管理。
 


### PR DESCRIPTION
有一处由于参考了中文文档，而导致的错误

Fix #7 